### PR TITLE
Pin a fixed PTB version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-telegram-bot>=20.0a0
+python-telegram-bot==20.0a0
 fastapi


### PR DESCRIPTION
Hi. Thanks for linking your template in the PTB wiki, contributions are always appreciated :)

I recommend to pin PTB in the requirements to a specific version, especially since you're specifying a pre-release as lower bound. For example, v20.0a5 & v20.0a6 made breaking changes to `File.download_*` so installing with this lower bound may lead to problems if the code was written for an older version. You may also want to specify the used version in the readme :)

Cheers,
Bibo-Joshi,
current maintainer of PTB